### PR TITLE
issue2 fixed

### DIFF
--- a/RechteDB/templates/rapp/panel_UhR.html
+++ b/RechteDB/templates/rapp/panel_UhR.html
@@ -26,7 +26,7 @@
 					({{ userHatRolle_liste.count }} Rollen)
 				</h3>
 			</div>
-			<div">
+			<div>
 				<table class="table table-striped table-sm">
 				<thead>
 					<tr class="bg-primary text-left">
@@ -141,6 +141,19 @@
 		{% else %}
 			{% if selektierter_name %}
 				<div class="col-12 bg-warning">User {{ selektierter_name }} ist noch keine Rolle zugeordnet</div>
+					<table class="table table-striped table-sm">
+						<tbody>
+							<tr>
+								<td>
+									<a href="{% url 'user_rolle_af-create' selektierte_userid %}">
+											<img src="{% static 'icons8-neu-erstellen-64.png' %}" width="25 rem" />
+									Hier</a>
+									können Sie neue Rollen für den User vergeben
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
 			{% else %}
 				<div class="col-12">
 					Kein User selektiert


### PR DESCRIPTION
Die entsprechende Zeile mit dem Link und dem Icon wurde eingefügt für den Fall, dass ein User ausgewählt ist, aber diesem User noch keine Rolle zugeordnet ist.

Der Fall, dass kein User ausgewählt wurde, benötigt den Button nicht.