### PR TITLE
fix issue23: Warum wird ewuerbghost nicht angezeigt

### DIFF
--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.4'
+__version__ = '0.0.5'
 VERSION = __version__  # synonym

--- a/RechteDB/templates/rapp/panel_UhR.html
+++ b/RechteDB/templates/rapp/panel_UhR.html
@@ -111,7 +111,7 @@
 											<div class="form-control col-5">{{ meineaf.bemerkung }}</div>
 											<div class="form-control col-1 text-center">
 												{# Aus dem QueryElement meineaf.af muss ein String zur Suche in der Menge gemacht werden #}
-												{% if meineaf.af|stringformat:"s" in afmenge %}
+												{% if meineaf.af|stringformat:"s"|lower in afmenge|lower %}
 													<img src="{% static 'admin/img/icon-yes.svg' %}">
 												{% else %}
 													<img src="{% static 'admin/img/icon-no.svg' %}">


### PR DESCRIPTION
Das Problem lag in der Klein-Großschreibung der AF.
Einige AFen wurden in lokalen Tabellen
(tblÜbersichtAF_GF und damit durch die Generiereung auch tbl_AFListe)
mixed-Case geschrieben.

Im Template wurden beide Vergleich-Strings auf lower case gesetzt,
damit klappt der Vergleich nun.