### PR TITLE
fix issue #34 -User-Selektion löschen  bei Auswahl

### DIFF
--- a/RechteDB/rapp/views.py
+++ b/RechteDB/rapp/views.py
@@ -407,6 +407,7 @@ def panel_UhR(request, id = 0):
 		Die af_menge wird benutzt zur Anzeige, welche der rollenbezogenen AFen bereits im IST vorliegt
 		
 		"""
+		print ('Wieder in panel_UhR Get')
 		usernamen = set()
 		userids = set()
 		for row in panel_liste:

--- a/RechteDB/templates/base.html
+++ b/RechteDB/templates/base.html
@@ -27,10 +27,7 @@
                 <div class="navbar-nav">
                     <a class="nav-item nav-link" <a href="{% url 'home' %}">Startseite <span class="sr-only">(current)</span></a>
                     <a class="nav-item nav-link" href="{% url 'panel' %}?geloescht=3&userid_name__geloescht=3&userid_name__zi_organisation=ai-ba">Suche</a>
-                    {% comment %}
-					<a class="nav-item nav-link" href="{% url 'user_rolle_af' %}?geloescht=3&userid_name__geloescht=3&userid_name__name=eichler, lutz">User und Rollen</a>
-                    {% endcomment %}
-					<a class="nav-item nav-link" href="{% url 'user_rolle_af' %}?userid__geloescht=3&userid__name=eichler, lutz">User und Rollen</a>
+					<a class="nav-item nav-link" href="{% url 'user_rolle_af' %}">User und Rollen</a>
                     <a class="nav-item nav-link" href="{% url 'import' %}">Import IIQ-Daten</a>
                     <a class="nav-item nav-link" href="{% url 'userliste' %}">UserID-Liste</a>
                     <a class="nav-item nav-link" href="{% url 'teamliste' %}">Team-Liste</a>

--- a/RechteDB/templates/search_few.html
+++ b/RechteDB/templates/search_few.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load widget_tweaks %}
 <div class="container">
-	<form method="get">
+	<form method="get" action="{% url 'user_rolle_af' %}">
 		<div >
 			<div class="row">
 				<div class="form-group form-group-sm col-12 col-sm-6 col-md-3 col-lg-3 col-xl-3">


### PR DESCRIPTION
Bei der Neueselktion der Suchkriterien wurde bislang der
letzte gefundene Eintrag nicht gelöscht.
Das lag an der URL - es wurde nicht die Standard-URL verwendet
als action für den Submit-Button, sondern die bisherige Adresse.
Und diese Adresse konnte bereits die Nummer eines Benutzers haben.

Durch Setzen des action-Attributs auf die Standard-URL
wurde das bereinigt.

Gegebenenfalls gibt es noch Quereinstiegs-Möglichkeiten
von anderen Seiten, das müsste dann ebenfalls angepasst werden.

Außerdem wurde bei Debugging festgestellt, dass die Aufruf-Suchparameter
für den Klick im Hauptmenü auf die User-und-Rollen-Suche falsch waren.
Sie wurden komplett entfernt.
