### PR TITLE
fix #13 warnings from strored procedures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ mariadb:
 		-v /home/lutz/Projekte/RechteDB2MySQL/RechteDB/mariadbconf.d:/etc/mysql/conf.d \
 		mariadb:10.2
 
-
 phpmyadmin:
 	docker run -d \
 		-p 8080:80 \
@@ -82,13 +81,14 @@ rapptest:
 		--network mariaNetz \
 		-v /home/lutz/Projekte/RechteDB2MySQL/RechteDB:/RechteDB \
 		-v /home/lutz/Projekte/RechteDB2MySQL/RechteDB/RechteDB:/RechteDB/code \
-		rapp:latest /RechteDB/code/manage.py test -v2
+		rapp:latest sh -c "echo yes | /RechteDB/code/manage.py test -v2"
 
 rappprod:
 	docker run -d \
 		--name rapp \
 		-p 8089:8000 \
 		--network mariaNetz \
+        --restart unless-stopped \
 		-v /home/lutz/Projekte/RechteDB2MySQL/RechteDB:/RechteDB \
 		-v /home/lutz/Projekte/RechteDB2MySQL/RechteDB/RechteDB:/RechteDB/code \
 		rapp:latest

--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 VERSION = __version__  # synonym

--- a/RechteDB/rapp/anmeldung.py
+++ b/RechteDB/rapp/anmeldung.py
@@ -4,9 +4,12 @@ from django.contrib.auth import authenticate
 # Die Hilfsklasse zum Login: User John Doe einrichten und anmelden.
 # Falls der User bereits existiert, einfach nur anmelden.
 class Anmeldung():
-	def __init__(self, loginfunc):
+	def login(self, loginfunc):
 		user = authenticate(username='john', password='123')
 		if user is None:
 			# No backend authenticated the credentials
 			user = User.objects.create_user(username='john', email='john@doe.com', password='123')
 		loginfunc (username=user, password='123')
+
+	def __init__(self, loginfunc):
+		self.login (loginfunc)

--- a/RechteDB/rapp/tests/test_login.py
+++ b/RechteDB/rapp/tests/test_login.py
@@ -8,6 +8,8 @@ from ..models import TblOrga, TblUebersichtAfGfs, TblUserIDundName, TblPlattform
 from datetime import datetime, timedelta
 from django.utils import timezone
 
+from ..tests.test_views import Setup_database
+
 
 # Ist das Login.-Panel verfügbar?
 class LoginTests(TestCase):
@@ -683,6 +685,7 @@ class LoginRequiredImportStatusTests(TestCase):
 class LoginRequiredAndExistingGesamtTests(TestCase):
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		self.url = reverse('gesamtliste')
 		self.response = self.client.get(self.url)
 

--- a/RechteDB/rapp/tests/test_views.py
+++ b/RechteDB/rapp/tests/test_views.py
@@ -11,7 +11,11 @@ from django.utils import timezone
 import re
 from ..anmeldung import Anmeldung
 
+
 class HomeTests(TestCase):
+	def setup(self):
+		Setup_database()
+
 	# Sind die einzelnen Hsuptseiten erreichbar?
 	# Generell: Funktioniert irgend etwas?
 	def test_something_is_running(self):
@@ -108,6 +112,7 @@ class GesamtlisteTests(TestCase):
 	# Funktioniert die Gesamtliste?
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 
 		for i in range (100):
 			TblOrga.objects.create(
@@ -236,6 +241,7 @@ class GesamtlisteTests(TestCase):
 class TeamListTests(TestCase):
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 	# Geht die Team-Liste?
 	# Ist die Seite da?
 	# ToDo: Beim Test der Teamliste fehlen noch die drei subpanels. Aber evtl. fällt die gesamte Liste weg
@@ -247,6 +253,7 @@ class CreateTeamTests(TestCase):
 	# Geht die Team-Liste inhaltlich?
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		TblOrga.objects.create(team='MeinTeam', themeneigentuemer='Icke')
 
 	def test_create_team_view_success_status_code(self):
@@ -268,6 +275,7 @@ class CreateTeamTests(TestCase):
 class UserListTests(TestCase):
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 	# Geht die User-Liste?
 	# Ist die Seite da?
 	def test_userlist_view_status_code(self):
@@ -278,6 +286,7 @@ class CreateUserTests(TestCase):
 	# Geht die User-Liste inhaltlich?
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		TblOrga.objects.create(team = 'Django-Team', themeneigentuemer = 'Ihmchen')
 
 		TblUebersichtAfGfs.objects.create(
@@ -329,6 +338,7 @@ class PanelTests(TestCase):
 	# Suche-/Filterpanel. Das wird mal die Hauptseite für Reports
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 
 		TblOrga.objects.create(
 			team = 'Django-Team-01',
@@ -459,11 +469,12 @@ class PanelTests(TestCase):
 		self.assertEquals(response.status_code, 200)
 		self.assertContains(response, "User_xv10099")
 
-class user_rolle_afTests(TestCase):
+class User_rolle_afTests(TestCase):
 	# User / Rolle / AF : Das wird mal die Hauptseite für
 	# Aktualisierungen / Ergänzungen / Löschungen von Rollen und Verbindungen
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		TblOrga.objects.create (
 			team = 'Django-Team-01',
 			themeneigentuemer = 'Ihmchen_01',
@@ -624,10 +635,11 @@ class user_rolle_afTests(TestCase):
 		self.assertContains(response, 'Schwerpunkt') # Wertigkeit in der Verantwortungsmatrix
 
 
-class import_new_csv_single_record(TestCase):
+class Import_new_csv_single_record(TestCase):
 	# Tests für den Import neuer CSV-Listen und der zugehörigen Tabellen
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		url = reverse('import')
 		self.response = self.client.get(url)
 
@@ -665,7 +677,7 @@ class import_new_csv_single_record(TestCase):
 		self.assertContains(self.response, 'csrfmiddlewaretoken')
 
 
-class setup_database(TestCase):
+class Setup_database(TestCase):
 	# Tests für den Import der Stored Procedures in die Datenbank
 	# Tests für den Import der Stored Procedures in die Datenbank
 	def setUp(self):
@@ -697,10 +709,11 @@ class setup_database(TestCase):
 		self.assertContains(self.response, 'setzeNichtAIFlag war erfolgreich.')
 
 
-class import_new_csv_single_record(TestCase):
+class Import_new_csv_single_record(TestCase):
 	# Tests für den Import neuer CSV-Listen und der zugehörigen Tabellen
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		url = reverse('import')
 		self.response = self.client.get(url)
 		# Lösche alle Einträge in der Importtabelle
@@ -740,13 +753,14 @@ class import_new_csv_single_record(TestCase):
 		num = Tblrechteneuvonimport.objects.filter(vorname = 'Fester').count()
 		self.assertEquals(num, 1)
 
-class import_new_csv_files_no_input(TestCase):
+class Import_new_csv_files_no_input(TestCase):
 	# Und nun Test des Imports dreier Dateien.
 	# Die erste Datei erstellt zwei User mit Rechten
 	# Die zweite Datei fügt einen User hinzu, ändert einen zweiten und löscht einen dritten
 	# Datei 3 löscht alle User und deren Rechte für die Organisation wieder.
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		url = reverse('import')
 		self.response = self.client.post(url, {})
 
@@ -764,13 +778,14 @@ class import_new_csv_files_no_input(TestCase):
 		self.assertTrue(form.errors)
 
 
-class import_new_csv_files_wrong_input(TestCase):
+class Import_new_csv_files_wrong_input(TestCase):
 	# Und nun Test des Imports dreier Dateien.
 	# Die erste Datei erstellt zwei User mit Rechten
 	# Die zweite Datei fügt einen User hinzu, ändert einen zweiten und löscht einen dritten
 	# Datei 3 löscht alle User und deren Rechte für die Organisation wieder.
 	def setUp(self):
 		Anmeldung(self.client.login)
+		Setup_database()
 		data = {
 			'organisation': 'foo blabla',
 		}

--- a/RechteDB/rapp/urls.py
+++ b/RechteDB/rapp/urls.py
@@ -15,9 +15,6 @@ Including another URLconf
 """
 from django.urls import path
 from . import views
-from django.conf.urls import url
-from django_filters.views import FilterView
-#from .filters import UserFilter
 
 # app_name = 'rapp'		# Wird nur benötigt als namespace, falls mehrere Apps dieselbe Teil-URL haben
 

--- a/RechteDB/rapp/views.py
+++ b/RechteDB/rapp/views.py
@@ -191,12 +191,12 @@ def userToggleGeloescht(request, pk):
 	# redirect to a new URL:
 	return HttpResponseRedirect(reverse('userliste') )
 
-
 ###################################################################
 # Die Gesamtliste der Teams (TblOrga)
 class TeamListView(LoginRequiredMixin, generic.ListView):
 	"""Die Gesamtliste der Teams (TblOrga)"""
 	model = TblOrga
+
 class TblOrgaCreate(LoginRequiredMixin, CreateView):
 	"""Neues Team erstellen"""
 	model = TblOrga
@@ -210,7 +210,6 @@ class TblOrgaDelete(LoginRequiredMixin, DeleteView):
 	"""Team löschen"""
 	model = TblOrga
 	success_url = reverse_lazy('teamliste')
-
 
 ###################################################################
 # Zuordnungen der Rollen zu den Usern (TblUserHatRolle ==> UhR)
@@ -248,8 +247,6 @@ class UhRCreate(LoginRequiredMixin, CreateView):
 		url = urlparams % reverse('user_rolle_af_parm', kwargs={'id': usernr})
 		# print (url)
 		return url
-
-
 class UhRDelete(LoginRequiredMixin, DeleteView):
 	"""Löscht die Zuordnung einer Rollen zu einem User."""
 	model = TblUserhatrolle
@@ -266,8 +263,6 @@ class UhRDelete(LoginRequiredMixin, DeleteView):
 				urlparams += "&" + k + "=" + self.request.GET[k]
 		url = urlparams % reverse('user_rolle_af_parm', kwargs={'id': usernr})
 		return url
-
-
 class UhRUpdate(LoginRequiredMixin, UpdateView):
 	"""Ändert die Zuordnung von Rollen zu einem User."""
 	# ToDo: Hierfür gibt es noch keine Buttons.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ django-widget-tweaks >= 1.4.2
 django-tables2 >= 1.21.2
 django-debug-toolbar >= 1.9.1
 django-import-export >= 1.1.0
+tblib >= 1.3.2
 
 # Images are at ${Project}./myvenv/lib/python3.5/site-packages/django/contrib/gis/static/gis/img


### PR DESCRIPTION
Durch die Verwendung der Stored Procedures für den Reimport
neuer Datenlisten werden bei den Tests Fehler geworfen.
Diese kamen durch eine ungünstig gewählte Reihenfole zustande
auf den völlig leeren und noch nicht mit SPs bestücketen Test-Datenbanken.

Durch eine entsprechende Initialisierung wurde der Fehler behoben.
Ergänzend wurde eine weitere Abhängigkeit geschaffen in requirements.txt,
um auch das parallele Ausführen der Tests auf n Datenbanken möglich zu machen.
Da der Aufgbau der DBen allerdings derzeit noch länger dauert
als die Testdurchführung, hat der Aufruf mit --parallel
derzeit noch keinen wirklichen Nutzen (8 Core, 8 DBen).
Aber er funktioniert derzeit mit 8 DBen, die allerdings im Vorfeld einmalig
im phpmyadmin angelegt werden mussten (ansonsten gab es Zugriffsfehler).
Dazu habe ich keine Hinweise im Web gefunden, scheint ein Mysterium zu sein.