### PR TITLE
fixes #7 AF-Anzeigen detaillieren

### DIFF
--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 VERSION = __version__  # synonym

--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.2'
+__version__ = '0.1.4'
 VERSION = __version__  # synonym

--- a/RechteDB/rapp/templatetags/gethash.py
+++ b/RechteDB/rapp/templatetags/gethash.py
@@ -1,0 +1,8 @@
+from django import template
+register = template.Library()
+
+@register.filter
+def hash(h, key):
+    if key in h:
+        return h[key]
+    return h

--- a/RechteDB/rapp/tests/test_views.py
+++ b/RechteDB/rapp/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.urls import reverse, resolve
 from django.test import TestCase
+
 from ..views import home
 
 from ..models import TblOrga, TblUebersichtAfGfs, TblUserIDundName, TblPlattform, TblGesamt, \
@@ -500,6 +501,11 @@ class User_rolle_afTests(TestCase):
 			neu_ab = 			timezone.now(),
 		)
 
+		TblAfliste.objects.create (
+			af_name = 			'rva_01219_beta91_job_abst_nicht_zugewiesen',
+			neu_ab = 			timezone.now(),
+		)
+
 		TblUserIDundName.objects.create (
 			userid = 			'xv13254',
 			name = 				'User_xv13254',
@@ -516,6 +522,12 @@ class User_rolle_afTests(TestCase):
 			rollenbeschreibung = 'Das ist eine Testrolle',
 		)
 
+		TblRollen.objects.create (
+			rollenname = 		'Zweite Neue Rolle',
+			system =			'Irgendein System',
+			rollenbeschreibung = 'Das ist auch eine Testrolle',
+		)
+
 		TblRollehataf.objects.create (
 			mussfeld =			True,
 			einsatz =			TblRollehataf.EINSATZ_XABCV,
@@ -524,16 +536,39 @@ class User_rolle_afTests(TestCase):
 			rollenname = 		TblRollen.objects.get(rollenname= 'Erste Neue Rolle'),
 		)
 
+		TblRollehataf.objects.create (
+			mussfeld =			True,
+			einsatz =			TblRollehataf.EINSATZ_XABCV,
+			bemerkung = 		'Irgend eine halbwegs sinnvolle Beschreibung',
+			af = 				TblAfliste.objects.get(af_name = 'rva_01219_beta91_job_abst_nicht_zugewiesen'),
+			rollenname = 		TblRollen.objects.get(rollenname= 'Erste Neue Rolle'),
+		)
+
+		TblRollehataf.objects.create (
+			mussfeld =			True,
+			einsatz =			TblRollehataf.EINSATZ_XABCV,
+			bemerkung = 		'Auch irgend eine halbwegs sinnvolle Beschreibung',
+			af = 				TblAfliste.objects.get(af_name = 'rva_01219_beta91_job_abst'),
+			rollenname = 		TblRollen.objects.get(rollenname= 'Zweite Neue Rolle'),
+		)
+
 		TblUserhatrolle.objects.create(
 			userid =	 		TblUserIDundName.objects.get(userid = 'xv13254'),
 			rollenname = 		TblRollen.objects.first(),
 			schwerpunkt_vertretung = 'Schwerpunkt',
 			bemerkung = 		'Das ist eine Testrolle für ZI-AI-BA-PS',
 			letzte_aenderung= 	timezone.now(),
-
 		)
 
-		# Die nächsten beiden Objekte werden wür tblGesamt als ForeignKey benötigt
+		TblUserhatrolle.objects.create(
+			userid =	 		TblUserIDundName.objects.get(userid = 'xv13254'),
+			rollenname = 		TblRollen.objects.get(rollenname = 'Zweite Neue Rolle'),
+			schwerpunkt_vertretung = 'Vertretung',
+			bemerkung = 		'Das ist auch eine Testrolle für ZI-AI-BA-PS',
+			letzte_aenderung= 	timezone.now(),
+		)
+
+		# Die nächsten beiden Objekte werden für tblGesamt als ForeignKey benötigt
 		TblUebersichtAfGfs.objects.create(
 			name_gf_neu = 		"GF-foo in tblÜbersichtAFGF",
 			name_af_neu =		"AF-foo in tblÜbersichtAFGF",
@@ -588,6 +623,25 @@ class User_rolle_afTests(TestCase):
 		response = self.client.get(url)
 		self.assertEquals(response.status_code, 200)
 		self.assertContains(response, "xv13254")
+	# Hat der User zwei Rollen?
+	def test_panel_view_with_deep_insight(self):
+		id = TblUserIDundName.objects.get(userid='xv13254').id
+		url = '{0}{1}/{2}'.format(reverse('user_rolle_af'), id, '?name=UseR&gruppe=BA-ps')
+		response = self.client.get(url)
+		self.assertEquals(response.status_code, 200)
+		self.assertContains(response, "User_xv13254")
+		self.assertContains(response, '(2 Rollen)')
+	# Sind bei einer der Rollen ein Recht nicht vergeben und zwei Rechte vergeben und insgesamt 3 Rechte behandelt?
+	def test_panel_view_with_deep_insight(self):
+		id = TblUserIDundName.objects.get(userid='xv13254').id
+		url = '{0}{1}/{2}'.format(reverse('user_rolle_af'), id, '?name=UseR&gruppe=BA-ps')
+		response = self.client.get(url)
+		self.assertEquals(response.status_code, 200)
+		self.assertContains(response, "User_xv13254")
+		self.assertContains(response, 'icon-yes', 5)
+		self.assertContains(response, 'icon-no', 1)
+
+
 	def test_panel_view_with_invalid_selection_status_code(self):
 		url = '{0}{1}'.format(reverse('user_rolle_af'), '?geloescht=99&zi_organisation=ZZ-XX')
 		response = self.client.get(url)

--- a/RechteDB/rapp/tests/test_views.py
+++ b/RechteDB/rapp/tests/test_views.py
@@ -506,6 +506,7 @@ class User_rolle_afTests(TestCase):
 			neu_ab = 			timezone.now(),
 		)
 
+		# Drei User: XV und DV aktiv, AV gelöscht
 		TblUserIDundName.objects.create (
 			userid = 			'xv13254',
 			name = 				'User_xv13254',
@@ -515,19 +516,38 @@ class User_rolle_afTests(TestCase):
 			abteilung = 		'ZI-AI-BA',
 			gruppe = 			'ZI-AI-BA-PS',
 		)
+		TblUserIDundName.objects.create (
+			userid = 			'dv13254',
+			name = 				'User_xv13254',
+			orga = 				TblOrga.objects.get(team = 'Django-Team-01'),
+			zi_organisation =	'AI-BA',
+			geloescht = 		False,
+			abteilung = 		'ZI-AI-BA',
+			gruppe = 			'ZI-AI-BA-PS',
+		)
+		TblUserIDundName.objects.create (
+			userid = 			'av13254',
+			name = 				'User_xv13254',
+			orga = 				TblOrga.objects.get(team = 'Django-Team-01'),
+			zi_organisation =	'AI-BA',
+			geloescht = 		True,
+			abteilung = 		'ZI-AI-BA',
+			gruppe = 			'ZI-AI-BA-PS',
+		)
 
+		# Zwei Rollen, die auf den XV-User vergeben werden
 		TblRollen.objects.create (
 			rollenname = 		'Erste Neue Rolle',
 			system =			'Testsystem',
 			rollenbeschreibung = 'Das ist eine Testrolle',
 		)
-
 		TblRollen.objects.create (
 			rollenname = 		'Zweite Neue Rolle',
 			system =			'Irgendein System',
 			rollenbeschreibung = 'Das ist auch eine Testrolle',
 		)
 
+		# Drei AF-Zuordnungen
 		TblRollehataf.objects.create (
 			mussfeld =			True,
 			einsatz =			TblRollehataf.EINSATZ_XABCV,
@@ -535,7 +555,6 @@ class User_rolle_afTests(TestCase):
 			af = 				TblAfliste.objects.get(af_name = 'rva_01219_beta91_job_abst'),
 			rollenname = 		TblRollen.objects.get(rollenname= 'Erste Neue Rolle'),
 		)
-
 		TblRollehataf.objects.create (
 			mussfeld =			True,
 			einsatz =			TblRollehataf.EINSATZ_XABCV,
@@ -543,15 +562,15 @@ class User_rolle_afTests(TestCase):
 			af = 				TblAfliste.objects.get(af_name = 'rva_01219_beta91_job_abst_nicht_zugewiesen'),
 			rollenname = 		TblRollen.objects.get(rollenname= 'Erste Neue Rolle'),
 		)
-
 		TblRollehataf.objects.create (
-			mussfeld =			True,
+			mussfeld =			False,
 			einsatz =			TblRollehataf.EINSATZ_XABCV,
 			bemerkung = 		'Auch irgend eine halbwegs sinnvolle Beschreibung',
 			af = 				TblAfliste.objects.get(af_name = 'rva_01219_beta91_job_abst'),
 			rollenname = 		TblRollen.objects.get(rollenname= 'Zweite Neue Rolle'),
 		)
 
+		# Dem XV-User werden zwei Rollen zugewiesen, dem AV- und DV-User keine
 		TblUserhatrolle.objects.create(
 			userid =	 		TblUserIDundName.objects.get(userid = 'xv13254'),
 			rollenname = 		TblRollen.objects.first(),
@@ -559,7 +578,6 @@ class User_rolle_afTests(TestCase):
 			bemerkung = 		'Das ist eine Testrolle für ZI-AI-BA-PS',
 			letzte_aenderung= 	timezone.now(),
 		)
-
 		TblUserhatrolle.objects.create(
 			userid =	 		TblUserIDundName.objects.get(userid = 'xv13254'),
 			rollenname = 		TblRollen.objects.get(rollenname = 'Zweite Neue Rolle'),
@@ -624,13 +642,22 @@ class User_rolle_afTests(TestCase):
 		self.assertEquals(response.status_code, 200)
 		self.assertContains(response, "xv13254")
 	# Hat der User zwei Rollen?
-	def test_panel_view_with_deep_insight(self):
+	def test_panel_view_num_userids(self):
+		id = TblUserIDundName.objects.get(userid='xv13254').id
+		url = '{0}{1}/{2}'.format(reverse('user_rolle_af'), id, '?name=UseR&gruppe=BA-ps')
+		response = self.client.get(url)
+		self.assertEquals(response.status_code, 200)
+		self.assertContains(response, "xv13254")
+		self.assertContains(response, "dv13254")
+	def test_panel_view_num_roles(self):
 		id = TblUserIDundName.objects.get(userid='xv13254').id
 		url = '{0}{1}/{2}'.format(reverse('user_rolle_af'), id, '?name=UseR&gruppe=BA-ps')
 		response = self.client.get(url)
 		self.assertEquals(response.status_code, 200)
 		self.assertContains(response, "User_xv13254")
-		self.assertContains(response, '(2 Rollen)')
+		#print('_____________')
+		#print (response.content)
+		self.assertContains(response, '(2 Rollen,')
 	# Sind bei einer der Rollen ein Recht nicht vergeben und zwei Rechte vergeben und insgesamt 3 Rechte behandelt?
 	def test_panel_view_with_deep_insight(self):
 		id = TblUserIDundName.objects.get(userid='xv13254').id
@@ -638,8 +665,8 @@ class User_rolle_afTests(TestCase):
 		response = self.client.get(url)
 		self.assertEquals(response.status_code, 200)
 		self.assertContains(response, "User_xv13254")
-		self.assertContains(response, 'icon-yes', 5)
-		self.assertContains(response, 'icon-no', 1)
+		self.assertContains(response, 'icon-yes', 4)
+		self.assertContains(response, 'icon-no', 2)
 
 
 	def test_panel_view_with_invalid_selection_status_code(self):

--- a/RechteDB/templates/rapp/panel_UhR.html
+++ b/RechteDB/templates/rapp/panel_UhR.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% load gethash %}
+
 {% load static %}
 {% load widget_tweaks %}
 { % load render_table from django_tables2 %}
@@ -23,7 +25,18 @@
 					<p>{{ form.non_field_errors }}</p>
 				{% endif %}
 				<h3>Rollen von {{ selektierter_name }}
-					({{ userHatRolle_liste.count }} Rollen)
+
+					({{ userHatRolle_liste.count }} {% if userHatRolle_liste.count == 1 %}Rolle,
+					{% else %}Rollen,
+					{% endif %}
+					UserID-Liste =
+					{% for x in selektierte_userids %}
+						{% if forloop.last %}
+							{{ x }})
+						{% else %}
+							{{ x }},
+						{% endif %}
+					{% endfor %}
 				</h3>
 			</div>
 			<div>
@@ -99,37 +112,69 @@
 							<td>&nbsp;</td>
 							<td colspan="5" >
 								<div class="collapse multi-collapse" id="rolle_{{ rolle }}">
-									<div class="row">
-										<div class="form-control bg-light text-success col-4">AF</div>
-										<div class="form-control bg-light text-success col-5">Anmerkung zur AF allgemein</div>
-										<div class="form-control bg-light text-success col-1 text-center">Aktiv</div>
-										<div class="form-control bg-light text-success col-1 text-center">Muss</div>
-										<div class="form-control bg-light text-success col-1 text-center">Einsatz</div>
-										{% for meineaf in rolle.rollenname.tblrollehataf_set.all %}
-											<div class="form-control col-4">{{ meineaf.af }}</div>
-											<div class="form-control col-5">{{ meineaf.bemerkung }}</div>
-											<div class="form-control col-1 text-center">
-												{# Aus dem QueryElement meineaf.af muss ein String zur Suche in der Menge gemacht werden #}
-												{% if meineaf.af|stringformat:"s"|lower in afmenge|lower %}
-													<img src="{% static 'admin/img/icon-yes.svg' %}">
-												{% else %}
-													<img src="{% static 'admin/img/icon-no.svg' %}">
-												{% endif %}
-											</div>
-											<div class="form-control col-1 text-center">
-												{% if meineaf.mussfeld %}
-													<img src="{% static 'admin/img/icon-yes.svg' %}">
-												{% else %}
-													<img src="{% static 'admin/img/icon-no.svg' %}">
-												{% endif %}
-											</div>
-										<div class="form-control select col-1 text-center">
-											<small>{{ meineaf.get_einsatz_display }}</small>
-										</div>
-										{% empty %}
-											<div class="form-control bg-danger col-12">Nix gefunden!?</div>
-										{% endfor rolle.rollenname.tblrollehataf_set.all %}
-									</div>
+									<table width="100%" class="table-striped table-sm table-hover" >
+										<thead>
+											<tr>
+												<th width="20%">
+													AF
+												</th>
+												<th width="45%">
+													Anmerkung zur AF allgemein
+												</th>
+												{% for uid in selektierte_userids %}
+													<th class="text-center">
+														{{ uid }}
+													</th>
+												{% endfor %}
+												<th class="text-center">
+													Muss
+												</th>
+												<th class="text-center">
+													Einsatz
+												</th>
+											</tr>
+										</thead>
+										<tbody>
+											{% for meineaf in rolle.rollenname.tblrollehataf_set.all %}
+												<tr>
+													<td>{{ meineaf.af }}</td>
+													<td>{{ meineaf.bemerkung }}</td>
+
+													{% for uid in selektierte_userids %}
+														<td class="text-center">
+															{% if uid|make_list|first|lower == "d" and meineaf.get_einsatz_display != "Nur DV-User" %}
+																&nbsp;
+															{% else %}
+																{# Aus dem QueryElement meineaf.af muss ein String zur Suche in der Menge gemacht werden #}
+																{% if meineaf.af|stringformat:"s"|lower in afmenge_je_userID|hash:uid|lower %}
+																	<img src="{% static 'admin/img/icon-yes.svg' %}">
+																{% else %}
+																	<img src="{% static 'admin/img/icon-no.svg' %}">
+																{% endif %}
+															{% endif %}
+														</td>
+													{% endfor %}
+
+													<td class="text-center">
+														{% if meineaf.mussfeld %}
+															<img src="{% static 'admin/img/icon-yes.svg' %}">
+														{% else %}
+															<img src="{% static 'admin/img/icon-no.svg' %}">
+														{% endif %}
+													</td>
+													<td class="text-center">
+														<small>{{ meineaf.get_einsatz_display }}</small>
+													</td>
+												</tr>
+											{% empty %}
+												<tr>
+													<td colspan="5">
+														<div class="form-control bg-danger col-12">Nix gefunden!?</div>
+													</td>
+												</tr>
+											{% endfor rolle.rollenname.tblrollehataf_set.all %}
+										</tbody>
+									</table>
 								</div>
 							</td>
 						</tr>


### PR DESCRIPTION
Der PR ändert die Anzeige unter "User hat Rolle".
Es werden nun alle vorhandenen Berechtigungen für jeden einzelnen User angezeigt.
Die Rechte für den DV-User werden nur bei Relevanz gezeigt (sonst stören die vielen roten Kreuze).
Die Testst sind auf die neue Anzeige angepasst.
Ein Pluralisierungsfehler wurde ebenfalls bereinigt (1 Rolle)