### PR TITLE
separate position of pdf button

### DIFF
--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 VERSION = __version__  # synonym

--- a/RechteDB/rapp/views.py
+++ b/RechteDB/rapp/views.py
@@ -623,6 +623,8 @@ def	UhR_konzept(request, ansicht):
 	else:
 		(rollenMenge, userids, usernamen) = (set(), set(), set())
 
+	(paginator, pages, pagesize) = pagination(request, namen_liste)
+
 	if request.GET.get('display') == '1':
 			print('rollenMenge')
 			print(rollenMenge)
@@ -636,6 +638,7 @@ def	UhR_konzept(request, ansicht):
 				print(a)
 
 	context = {
+		'paginator': paginator, 'pages': pages, 'pagesize': 20,
 		'filter': panel_filter,
 		'rollenMenge': rollenMenge,
 		'version': version,

--- a/RechteDB/templates/rapp/panel_UhR_konzept.html
+++ b/RechteDB/templates/rapp/panel_UhR_konzept.html
@@ -24,6 +24,14 @@
 				{% endif %}
 			</div>
 			<div>
+				<a href="{% url 'uhr_konzept_pdf' %}?{% for key,value in request.GET.items %}{{ key }}={{ value }}&{%endfor %}"
+				   class="btn btn-success btn-sm" role="button"
+				   target="_blank" style="width:100%">
+					<i class="fa fa-download"></i>Erzeuge PDF
+				</a>
+			</div>
+
+			<div>
 				<table class="table table-striped table-sm">
 					<thead>
 						<tr>

--- a/RechteDB/templates/search_few.html
+++ b/RechteDB/templates/search_few.html
@@ -32,10 +32,7 @@
 				<div class="form-group-sm col-12 col-sm-12 col-md-12 col-lg-4 col-xl-4 mt-3 pt-3">
 					<button type="submit" class="btn btn-primary btn-sm">Suche</button>
 					<a href="{% url 'uhr_konzept_ansicht' %}?{% for key,value in request.GET.items %}{{ key }}={{ value }}&{%endfor %}"
-						class="btn btn-outline-success btn-sm" role="button">Ansicht
-					</a>
-					<a href="{% url 'uhr_konzept_pdf' %}?{% for key,value in request.GET.items %}{{ key }}={{ value }}&{%endfor %}"
-						class="btn btn-outline-success btn-sm" role="button">PDF
+						class="btn btn-outline-success btn-sm" role="button">Konzept
 					</a>
 					<a href="{% url 'home' %}"
 						class="btn btn-outline-secondary btn-sm"


### PR DESCRIPTION
Der Button zum Erzeugen des PDF ist auf die KOnzept-Seite verlagert worden.
Hintergrund sind die voraussichtlich noch anzufallenden, weiteren PDF-Generiereungs-Buttons.

Außerdem wurde ein Effekt bereinigt: BVei der Anzeige des Konzepts
ist bislang in der Namensliste "keine Treffer" erschienen, weil die
Paginierungsinformationen nicht mitgeliefert wurden.
Zwar wird diese Liste normalerweise nie paginiert,
aber die Pages-lines sind der Iterator für die Namensanzeige.