### PR TITLE
Issue94 teamanzeige in funktionsmatrix

### DIFF
--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 VERSION = __version__  # synonym

--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 VERSION = __version__  # synonym

--- a/RechteDB/rapp/filters.py
+++ b/RechteDB/rapp/filters.py
@@ -1,4 +1,4 @@
-from .models import TblGesamt, TblUserIDundName, TblUserhatrolle
+from .models import TblGesamt, TblUserIDundName, TblUserhatrolle, TblRollehataf
 import django_filters
 
 class PanelFilter(django_filters.FilterSet):
@@ -86,6 +86,21 @@ class RollenFilter(django_filters.FilterSet):
 			'userid__gruppe',
 			'userid__orga',
 			'rollenname',
-			# 'afname',
+		]
+
+# Filter für das halbautomatische Selektieren über die Arbeitsplatzfunktion.
+# Wird insbesondere in der AF-Factory bei UhR genutzt
+class RolleAFFilter(django_filters.FilterSet):
+	rollenname = 		django_filters.CharFilter(lookup_expr='istartswith')
+	af = 				django_filters.CharFilter(lookup_expr='istartswith')
+	af__af_name = 		django_filters.CharFilter(lookup_expr='istartswith')
+
+	class Meta:
+		model = TblRollehataf
+		fields = [
+			'rollenname',
+			'rollenname__rollenname',
+			'af__af_name',
+			'mussfeld',
 		]
 

--- a/RechteDB/templates/rapp/panel_UhR_matrix.html
+++ b/RechteDB/templates/rapp/panel_UhR_matrix.html
@@ -66,6 +66,7 @@
 					<thead>
 						<tr class="bg-primary text-left">
 							<th width="10%">Name</th>
+							<th width="10%">Teams</th>
 							{% for rolle in rollenmenge %}
 								<th><small>{{ rolle }}</small></th>
 							{% endfor %}
@@ -77,12 +78,19 @@
 							<td>
 								{{ user }}
 							</td>
+							<td>
+								{% for team in teams_je_username|hash:user %}
+									<small>
+										{{ team }}{% if not forloop.last %},<br />{% endif %}
+									</small>
+								{% endfor %}
+							</td>
 							{% for rolle in rollenmenge %}
-								<th>
+								<td>
 									<small>
 										{{ rollen_je_username|hash:user|finde:rolle }}
 									</small>
-								</th>
+								</td>
 							{% endfor %}
 						</tr>
 					{% endfor usernamen %}

--- a/RechteDB/templates/rapp/panel_UhR_rolle.html
+++ b/RechteDB/templates/rapp/panel_UhR_rolle.html
@@ -50,9 +50,12 @@
 									<td>
 										{% for rolle in vorhanden|hash2:uid|hash3:af %}
 											{# Als letztes Element wird immer ein Leerstring geliefert! #}
+											{% if forloop.first and rolle == ""%}
+												<strong class="text-danger">nicht vergeben</strong>
+											{% endif %}
 											{% if not forloop.last %}{{ rolle }}<br />{% endif %}
 										{% empty %}
-											Keine Rolle vergeben
+											Fehler im Datensatz
 										{% endfor vorhanden %}
 									</td>
 									<td>


### PR DESCRIPTION
Die Anzeige der Teamliste (für alle Userids, falls die Teamzuordnungen unterschiedlich sind) erfolgt nun in der HTML-Ansicht.
Da diese Zuordnung intern ist und damit die Revision / WP nicht interessieren sollte, ist die Anzeige auch nicht ins PDF übernommen worden.

Nicht angezeigt werden UserIDs, bei denen die Teamzugehörigkeit bereits auf "Gelöschter User" gesetzt wurde. Das wird über einen anderen Issue #97 weiterverfolgt:
