### PR TITLE
add page breaks in PDF for very large role-sets

### DIFF
--- a/RechteDB/rapp/view_UserHatRolle.py
+++ b/RechteDB/rapp/view_UserHatRolle.py
@@ -20,6 +20,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 
 from .templatetags.gethash import finde
+from django.utils import timezone
 
 ###################################################################
 # Zuordnungen der Rollen zu den Usern (TblUserHatRolle ==> UhR)
@@ -477,7 +478,6 @@ class UhR(object):
 			return AFListenUhr()
 		assert 0, "Falsche Factory-Typ in Uhr: " + typ
 	factory = staticmethod(factory)
-
 class EinzelUhr(UhR):
 	def behandle(self, request, id):
 		"""
@@ -509,7 +509,6 @@ class EinzelUhr(UhR):
 			'version': version,
 		}
 		return render(request, 'rapp/panel_UhR.html', context)
-
 class RollenListenUhr(UhR):
 	def behandle(self, request, _):
 		"""
@@ -540,7 +539,6 @@ class RollenListenUhr(UhR):
 			'version': version,
 		}
 		return render(request, 'rapp/panel_UhR_rolle.html', context)
-
 class AFListenUhr(UhR):
 	def behandle(self, request, id):
 		return ''
@@ -571,6 +569,12 @@ def panel_UhR(request, id = 0):
 
 	obj = UhR.factory(name)
 	return obj.behandle(request, id)
+
+def erzeuge_pdf_namen(request):
+	name = 'Berechtigungskonzept_{}_{}.pdf' \
+		.format(request.GET.get('gruppe', ''), timezone.now())
+	print ('Name der Datei wird:', name)
+	return name
 
 # Erzeuge das Berechtiogungskonzept für Anzeige und PDF
 def	erzeuge_UhR_konzept(request, ansicht):
@@ -616,11 +620,11 @@ def	erzeuge_UhR_konzept(request, ansicht):
 	pdf = render_to_pdf('rapp/panel_UhR_konzept_pdf.html', context)
 	if pdf:
 		response = HttpResponse(pdf, content_type='application/pdf')
-		filename = "Berechtigungskonzept_%s.pdf" % ("hierMussNochEinVernünftigerNameHin")
-		content = "inline; filename='%s'" % (filename)
+		filename = erzeuge_pdf_namen(request)
+		content = "inline; filename={}".format(filename)
 		download = request.GET.get("download")
 		if download:
-			content = "attachment; filename='%s'" % (filename)
+			content = "attachment; filename={}".format(filename)
 		response['Content-Disposition'] = content
 		return response
 	return HttpResponse("Fehlerhafte PDF-Generierung in erzeuge_UhR_konzept")

--- a/RechteDB/templates/rapp/panel_UhR_konzept_pdf.html
+++ b/RechteDB/templates/rapp/panel_UhR_konzept_pdf.html
@@ -34,17 +34,17 @@
 		<h1>User, Rollen und Arbeitsplatzfunktionen</h1>
 
 		{% if rollenMenge %}
-			<div>
-				<table repeat="1" id="pdfdruck">
-					<thead>
-						<tr>
-							<th colspan="2" style="text-align: left;"><br />Rollennname</th>
-							<th colspan="2" style="text-align: left;"><br />Beschreibung</th>
-							<th colspan="1" style="text-align: left;"><br />System</th>
-						</tr>
-					</thead>
-					<tbody>
-						{% for rolle in rollenMenge %}
+			{% for rolle in rollenMenge %}
+				<div>
+					<table repeat="0" id="pdfdruck">
+						<thead>
+							<tr>
+								<th colspan="2" style="text-align: left;"><br />Rollennname</th>
+								<th colspan="2" style="text-align: left;"><br />Beschreibung</th>
+								<th colspan="1" style="text-align: left;"><br />System</th>
+							</tr>
+						</thead>
+						<tbody>
 							<tr><td>&nbsp;</td></tr>
 							<tr>
 								<td colspan="2">
@@ -60,7 +60,7 @@
 							<tr>
 								<td>&nbsp;</td>
 								<td colspan="4">
-									<table repeat="1" id="pdfdruck2">
+									<table repeat="0" id="pdfdruck2">
 										<head>
 											<tr>
 												<td width="30%"><strong>AF</strong></td>
@@ -71,35 +71,40 @@
 										</head>
 										<tbody>
 											{% for meineaf in rolle.tblrollehataf_set.all %}
-												{% if forloop.counter0 >= 50 %}
-													{% if forloop.counter0 == 50 %}
-														<tr>
-															<td colspan="4">
-																<strong style="color: red;">
-																	Achtung, die Rolle enthält mehr als
-																	{{ forloop.counter0 }} Elemente.
-																	Es fehlen noch {{ forloop.revcounter }} Zeilen.
-																</strong>
-															</td>
-														</tr>
-													{% endif %}
-												{% else %}
-													<tr>
-														<td>{{ meineaf.af }}</td>
-														<td class="text-center">
-															{% if meineaf.mussfeld %}
-																<img src="static/checkbox-checked.jpg"
-																	 alt="checkbox checked" height="10" width="10">
-															{% else %}
-																<img src="static/checkbox-blank.jpg"
-																	 alt="checkbox checked" height="10" width="10">
-															{% endif %}
-														</td>
-														<td class="text-center">
-															<small>{{ meineaf.get_einsatz_display }}</small>
-														</td>
-														<td>{{ meineaf.bemerkung }}</td>
-													{% endif %}
+												{% if forloop.counter0 > 0 and forloop.counter0|divisibleby:45 %}
+										</tbody></table>
+									</tbody></table>
+
+									<table repeat="0" id="pdfdruck">
+												<tr>
+													<td>&nbsp;</td>
+													<td colspan="4">
+										<table repeat="1" id="pdfdruck2">
+											<head>
+												<tr>
+													<td width="30%"><strong>AF</strong></td>
+													<td width="5%"><strong>Muss</strong></td>
+													<td width="15%"><strong>Einsatz</strong></td>
+													<td width="50%"><strong>Anmerkung zur AF</strong></td>
+												</tr>
+											</head>
+											<tbody>
+												{% endif %}
+												<tr>
+													<td>{{ meineaf.af }}</td>
+													<td class="text-center">
+														{% if meineaf.mussfeld %}
+															<img src="static/checkbox-checked.jpg"
+																 alt="checkbox checked" height="10" width="10">
+														{% else %}
+															<img src="static/checkbox-blank.jpg"
+																 alt="checkbox checked" height="10" width="10">
+														{% endif %}
+													</td>
+													<td class="text-center">
+														<small>{{ meineaf.get_einsatz_display }}</small>
+													</td>
+													<td>{{ meineaf.bemerkung }}</td>
 												</tr>
 											{% empty %}
 												<tr>
@@ -111,9 +116,12 @@
 										</tbody>
 									</table>
 								</td>
-						{% endfor userHabenRollen %}
-					</tbody>
-				</table>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<p>&nbsp</p>
+				{% endfor userHabenRollen %}
 			{% else %}
 				<div class="text-danger">
 					<p>


### PR DESCRIPTION
Das Generieren des PDF für sehr lange Rollenlisten wurde angepasst. Die Listen werden nun über mehrere Seiten erzeugt, die vorher implementierte Fehlermeldung ist eliminiert.
Das Erzeugen von Waisen ("Schusterjungen") lässt sich leider nicht vermeiden, weil die Schnittstelle anscheinend keine Möglichkeit hat, ihr über das Template einen Hinweis auf einen Pagebreak zu liefern.

Wenn  jemand in der Doku finden sollte, wie man über das Template dem PDF-Generator eine entsprechende Anweisung geben kann, dann bitte Issue wieder aufmachen und kommentieren.