### PR TITLE
fix #158 handmade 'in'-function 'vergleich'

### DIFF
--- a/RechteDB/rapp/__init__.py
+++ b/RechteDB/rapp/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.5.15'
+__version__ = '0.5.16'
 VERSION = __version__  # synonym

--- a/RechteDB/rapp/templatetags/gethash.py
+++ b/RechteDB/rapp/templatetags/gethash.py
@@ -59,3 +59,11 @@ def sort(menge):
 	liste = list(menge)
 	liste.sort()
 	return liste
+
+@register.filter
+def vergleich(einzel, menge):
+	for element in menge:
+		if element == einzel:
+			print ('gefunden:', element, einzel)
+			return True
+	return False

--- a/RechteDB/templates/rapp/panel_UhR.html
+++ b/RechteDB/templates/rapp/panel_UhR.html
@@ -160,11 +160,16 @@
 																&nbsp;
 															{% else %}
 																{# Aus dem QueryElement meineaf.af muss ein String zur Suche in der Menge gemacht werden #}
-																{% if meineaf.af|stringformat:"s"|lower in afmenge_je_userID|hash:uid|lower %}
-																	<img src="{% static 'admin/img/icon-yes.svg' %}">
-																{% else %}
-																	<img src="{% static 'admin/img/icon-no.svg' %}">
-																{% endif %}
+																{# Das folgende Statement geht leider nicht (findet falsche Substrings: #}
+																{# if meineaf.af|stringformat:"s"|lower in afmenge_je_userID|hash:uid|lower #}
+																{# Also musste ein programmierter Vergleich her #}
+																{% with menge=afmenge_je_userID|hash:uid %}
+																	{% if meineaf.af|stringformat:"s"|lower|vergleich:menge %}
+																		<img src="{% static 'admin/img/icon-yes.svg' %}">
+																	{% else %}
+																		<img src="{% static 'admin/img/icon-no.svg' %}">
+																	{% endif %}
+																{% endwith %}
 															{% endif %}
 														</td>
 													{% endfor %}


### PR DESCRIPTION
fix #158 
Die im Template verwendete Suchfunktion "in" liefert leider auf Resultate, die sich nicht auf komplette Strings beziehen, sondern auf Teilstrings. Das führte zu dem im Issue aufgezeigten Fehler.
Bei der Export-Funktion wurden die Daten nicht über ein Template gefiltert, deshalb war dort die Anzeige korrekt.